### PR TITLE
Better behavior when run with piped stdin

### DIFF
--- a/rcon_client.go
+++ b/rcon_client.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	rcon "github.com/TF2Stadium/TF2RconWrapper"
+	isatty "github.com/mattn/go-isatty"
 )
 
 func main() {
@@ -31,10 +32,18 @@ func main() {
 	}
 
 	reader := bufio.NewReader(os.Stdin)
+	isCLI := isatty.IsTerminal(os.Stdin.Fd())
 
 	for {
-		fmt.Print("RCON> ")
-		query, _ := reader.ReadString('\n')
+		if isCLI {
+			fmt.Print("RCON> ")
+		}
+
+		query, readErr := reader.ReadString('\n')
+		if readErr != nil {
+			break
+		}
+
 		reply, err := conn.Query(query)
 		if err != nil {
 			if err == rcon.ErrUnknownCommand {


### PR DESCRIPTION
Compare before:

```
$ echo "status" | go run rcon_client.go -addr=example.com:27015 -pwd=password1
hostname: TF2 Server
version : 3442593/24 3442593 secure
udp/ip  : 1.2.3.4:27015  (public ip: 23.92.22.188)
account : not logged in  (No account specified)
map     : cp_powerhouse at: 0 x, 0 y, 0 z
tags    : cp,nocrits,nodmgspread,norespawntime
players : 0 humans, 0 bots (24 max)
edicts  : 684 used of 2048 max
         Spawns Points Kills Deaths Assists
Scout         0      0     0      0       0
Sniper        0      0     0      0       0
Soldier       0      0     0      0       0
Demoman       0      0     0      0       0
Medic         0      0     0      0       0
Heavy         0      0     0      0       0
Pyro          0      0     0      0       0
Spy           0      0     0      0       0
Engineer      0      0     0      0       0

# userid name                uniqueid            connected ping loss state  adr
Loaded plugins:
---------------------
0:  "TFTrue v4.77, AnAkkk"
1:  "Metamod:Source 1.10.6"
---------------------

RCON> 
RCON> 
RCON> 
RCON> 
RCON> 
RCON> ^Csignal: interrupt
$ 
```

(Note the RCON> prompts endlessly repeat themselves, sending empty-string commands to the server)

After:

```
$ echo "status" | go run rcon_client.go -addr=example.com:27015 -pwd=password1
hostname: TF2 Server
version : 3442593/24 3442593 secure
udp/ip  : 1.2.3.4:27015  (public ip: 23.92.22.188)
account : not logged in  (No account specified)
map     : cp_powerhouse at: 0 x, 0 y, 0 z
tags    : cp,nocrits,nodmgspread,norespawntime
players : 0 humans, 0 bots (24 max)
edicts  : 684 used of 2048 max
         Spawns Points Kills Deaths Assists
Scout         0      0     0      0       0
Sniper        0      0     0      0       0
Soldier       0      0     0      0       0
Demoman       0      0     0      0       0
Medic         0      0     0      0       0
Heavy         0      0     0      0       0
Pyro          0      0     0      0       0
Spy           0      0     0      0       0
Engineer      0      0     0      0       0

# userid name                uniqueid            connected ping loss state  adr
Loaded plugins:
---------------------
0:  "TFTrue v4.77, AnAkkk"
1:  "Metamod:Source 1.10.6"
---------------------

$
```

(Note: properly terminates after command in run)
